### PR TITLE
fix: syntax

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,12 +19,12 @@ runs:
       
     - name: Post to Mastodon
       uses: nick-fields/retry@v2
+      env:
+        MASTODONBOT: ${{ secrets.MASTODONBOT }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
       with:
         timeout_minutes: 10
         max_attempts: 3
-        env:
-          MASTODONBOT: ${{ secrets.MASTODONBOT }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
         command: |
           chmod +x $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py
           $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py


### PR DESCRIPTION
Last run yielded:

```
Error: snakemake/mastodon-release-post-action/v1/action.yml (Line: 26, Col: 11): A mapping was not expected
Error: System.ArgumentException: Unexpected type 'MappingToken' encountered while reading 'inputs value'. The type 'StringToken' was expected.
```

Attempt to move token access to `env` section.