### PR TITLE
fix: removing secrets - only to be tried in the workflow, not the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,5 @@ runs:
         timeout_minutes: 10
         max_attempts: 3
         command: |
-          export MASTODONBOT="${{ secrets.MASTODONBOT }}"
-          export PR_TITLE="${{ github.event.pull_request.title }}"
           chmod +x $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py
           $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py


### PR DESCRIPTION
not sure, it will fix the issue of accessing the MASTODON secret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Action workflow by removing the export of certain environment variables in the "Post to Mastodon" step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->