### PR TITLE
fix: attempting to hand over message and access token as inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
   message:
     description: 'The message to post to Mastodon'
     required: true
+  access-token:
+    description: 'Mastodon access token for authentication'
+    required: true
 
 runs:
   using: "composite"
@@ -24,4 +27,7 @@ runs:
         max_attempts: 3
         command: |
           chmod +x $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py
-          $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py
+          $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py \
+            --message "${{ inputs.message }}" \
+            --access-token ${{ input.access-token }} 
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ runs:
           chmod +x $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py
           $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py \
             --message "${{ inputs.message }}" \
-            --access-token ${{ input.access-token }} 
+            --access-token "${{ inputs.access-token }}"
       shell: bash

--- a/post_to_mastodon.py
+++ b/post_to_mastodon.py
@@ -13,11 +13,12 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--message", help="Message to post to Mastodon")
+parser.add_argument("--message", required=True, help="Message to post to Mastodon")
+parser.add_argument("--access-token", required=True, help="Mastodon access token")
 args = parser.parse_args()
 
 # Configure Mastodon connection
-mastodon_access_token = os.environ.get("MASTODONBOT")
+mastodon_access_token = os.environ.get("MASTODONBOT", args.access_token)
 mastodon_base_url = os.environ.get("MASTODON_BASE_URL", "https://fediscience.org")
 
 if not mastodon_access_token:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a required input for Mastodon access token when using the GitHub Action.
	- Enhanced authentication by allowing the access token to be provided via input or environment variable.

- **Refactor**
	- Made the message input mandatory for posting to Mastodon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->