### PR TITLE
fix: deleted 'shell' directive, apparently not allowed here

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,3 @@ runs:
           $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.py \
             --message "${{ inputs.message }}" \
             --access-token "${{ inputs.access-token }}"
-      shell: bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Action workflow by removing the explicit shell specification for the "Post to Mastodon" step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->