### PR TITLE
fix: interface

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,11 @@ runs:
           if [ -n "${{ inputs.base-url }}" ]; then
             args+=(--base-url "${{ inputs.base-url }}" )
           fi
+          if [ -n "${{ inputs.image }}" ]; then
+            args+=(--image "${{ inputs.image }}" )
+          fi
+          if [ -n "${{ inputs.image-description }}" ]; then
+            args+=(--image-description "${{ inputs.image-description }}" )
+          fi
           python3 "${{ github.action_path }}/post_to_mastodon.py" "${args[@]}"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The “Post to Mastodon on Release” action now supports attaching an image to your release post via a new image input.
  * Added support for providing an image description (alt text) to improve accessibility, via a new image-description input.
  * Both inputs are optional; when omitted, behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->